### PR TITLE
Fix recipe unlock condition

### DIFF
--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.16.5/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.17.1/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.18.1/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.18.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.18.2/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/acacia.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:acacia_log"
+            "items": ["minecraft:acacia_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/bamboo.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:bamboo"
+            "items": ["minecraft:bamboo"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/birch.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:birch_log"
+            "items": ["minecraft:birch_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/crimson.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:crimson_stem"
+            "items": ["minecraft:crimson_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/dark_oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:dark_oak_log"
+            "items": ["minecraft:dark_oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/jungle.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:jungle_log"
+            "items": ["minecraft:jungle_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/mangrove.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:mangrove_log"
+            "items": ["minecraft:mangrove_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/metal.json
@@ -20,7 +20,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/oak.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:oak_log"
+            "items": ["minecraft:oak_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/spruce.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:spruce_log"
+            "items": ["minecraft:spruce_log"]
           }
         ]
       }

--- a/1.19/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
+++ b/1.19/src/main/resources/data/mcwdoors/advancements/recipes/warped.json
@@ -31,7 +31,7 @@
       "conditions": {
         "items": [
           {
-            "item": "minecraft:warped_stem"
+            "items": ["minecraft:warped_stem"]
           }
         ]
       }


### PR DESCRIPTION
(This is the same PR as for Macaw's Trapdoors, except for Macaw's Doors)

In Minecraft 1.19.2 (and likely every other version), picking up any item immediately unlocks all recipes added by this mod. This is unintentional, since the advancements specify only certain items should unlock it. This PR fixes that.

According to the [Minecraft wiki](https://minecraft.fandom.com/wiki/Advancement/JSON_format#minecraft:inventory_changed), the objects in the conditions.items array should contain a key named "items", not "item", whose value is an array of strings, not a single string.

These changes were made automatically using the following command in the Zsh shell on Linux (macOS's BSD variant of sed doesn't support the -i option as used here):

```sh
sed -i -E 's/"item": (.+)/"items": [\1]/' **/advancements/**/*.json
```

You should be able to use this command to make the same changes to the rest of your mods; I have submitted PRs for only those mods I am personally using :)