### PR TITLE
Mangrove bamboo door fix

### DIFF
--- a/1.19 fabric/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
+++ b/1.19 fabric/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:bamboo"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":

--- a/1.19.1 fabric/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
+++ b/1.19.1 fabric/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:bamboo"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":

--- a/1.19.1/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
+++ b/1.19.1/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:bamboo"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":

--- a/1.19.2 fabric/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
+++ b/1.19.2 fabric/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:bamboo"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":

--- a/1.19.2/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
+++ b/1.19.2/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:bamboo"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":

--- a/1.19.3 fabric/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
+++ b/1.19.3 fabric/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:bamboo"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":

--- a/1.19.3/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
+++ b/1.19.3/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:bamboo"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":

--- a/1.19/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
+++ b/1.19/src/main/resources/data/mcwdoors/recipes/mangrove_bamboo_door.json
@@ -13,7 +13,7 @@
     { 
         "A":
         {
-            "item": "minecraft:bamboo"
+            "item": "minecraft:mangrove_planks"
         },    
         
         "B":


### PR DESCRIPTION
Fixed typo in recipe for mangrove bamboo door to use mangrove planks instead of bamboo

